### PR TITLE
#12 Provide a German language file

### DIFF
--- a/lang/de/atto_pastespecial.php
+++ b/lang/de/atto_pastespecial.php
@@ -1,0 +1,47 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for component 'atto_pastespecial', language 'de'.
+ *
+ * @package    atto_pastespecial
+ * @copyright  2015 Joseph Inhofer
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['pluginname'] = 'Paste special';
+$string['pastehere'] = 'Inhalt hier einfügen';
+$string['pastefromword'] = 'Einfügen aus Microsoft Word';
+$string['pastefromgdoc'] = 'Einfügen aus Google Document';
+$string['pastefromlibre'] = 'Einfügen aus LibreWriter';
+$string['pastefromother'] = 'Einfügen aus anderer Anwendung';
+$string['pasteunformatted'] = 'Einfügen als unformatierten Text';
+$string['paste'] = 'Einfügen';
+$string['settings'] = 'Einstellungen für Paste special';
+$string['wordCSS_desc'] = 'Erlaubte CSS-Eigenschaften beim Einfügen aus Microsoft Word (Format siehe Standard)';
+$string['gdocCSS_desc'] = 'Erlaubte CSS-Eigenschaften beim Einfügen aus Google Document (Format siehe Standard)';
+$string['libreCSS_desc'] = 'Erlaubte CSS-Eigenschaften beim Einfügen aus LibreWriter (Format siehe Stan dard)';
+$string['otherCSS_desc'] ='Erlaubte CSS-Eigenschaften beim Einfügen aus anderer Anwendung (Format siehe Standard)';
+$string['wordCSS'] = 'Word CSS-Eigenschaften';
+$string['gdocCSS'] = 'Google Document CSS-Eigenschaften';
+$string['libreCSS'] = 'LibreWriter CSS-Eigenschaften';
+$string['otherCSS'] = 'Andere Anwendung CSS-Eigenschaften';
+$string['wordCSS_default'] = 'font-family,font-size,background,color,background-color';
+$string['gdocCSS_default'] = 'background-color,color,font-family,font-size,font-weight,font-style,text-decoration,list-style-type,text-align';
+$string['libreCSS_default'] = 'background,color,font-size';
+$string['default'] = '"Paste sppecial" standardmässig aktiviert';
+$string['default_desc'] = 'Wenn aktiviert, öffnet der Tastaturbefehl (ctrl-v / cmd-v) "Paste special" anstatt den Inhalt der Zwischenablage direkt einzufügen.';
+$string['pasteview'] = 'Vorschau:';


### PR DESCRIPTION
I have created the German language file. It is not that much a word by word translation but a transfer to german as far as I understood the semantics.

For Example:

```php
$string['default_desc'] = 'Set this plugin to handle pasting by keyboard instead of automatically pasting';
$string['pasteview'] = 'Preview:';
```
is 
```php
$string['default_desc'] = 'Wenn aktiviert, öffnet der Tastaturbefehl (ctrl-v / cmd-v) "Paste special" anstatt den Inhalt der Zwischenablage direkt einzufügen.';
$string['pasteview'] = 'Vorschau:';
````
which is in word by word:

```php
"if activated, the keyboard commad (ctl-v / cmd-v) opens "Paste special" instead of pasting the clipboard contents directly"
```

I zipped the plugin and installed in in my incubator to see if the texts make sense in the related contexts.

BTW: is there another way to update a plugin without the need to deinstall it first?

